### PR TITLE
Add FastBoot support

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+jshint:
+  config_file: .jshintrc

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "esversion": 6,
   "predef": [
     "document",
     "window",

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
+  - "6"
+  - "7"
 
 sudo: false
 

--- a/blueprints/ember-cli-mousewheel/index.js
+++ b/blueprints/ember-cli-mousewheel/index.js
@@ -8,11 +8,10 @@ module.exports = {
   //     foo: options.entity.options.foo
   //   };
   // }
-  
+
   normalizeEntityName: function() {
   },
 
   afterInstall: function(options) {
-    return this.addBowerPackageToProject('jquery-mousewheel');
   }
 };

--- a/index.js
+++ b/index.js
@@ -37,8 +37,6 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import({
-      development: 'vendor/jquery.mousewheel.js'
-    });
+    app.import('vendor/jquery.mousewheel.js');
   }
 };

--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ module.exports = {
     var mousewheelTree = new Funnel(mousewheelDir, {
       files: ['jquery.mousewheel.js']
     });
-    mousewheelTree = new BroccoliDebug(mousewheelTree, 'ember-cli-mousewheel:mousewheel-tree');
+    mousewheelTree = new BroccoliDebug(
+      mousewheelTree, 'ember-cli-mousewheel:mousewheel-tree'
+    );
 
     if (vendorTree) {
       vendorTree = mergeTrees([vendorTree, mousewheelTree]);
@@ -27,7 +29,9 @@ module.exports = {
       vendorTree = mousewheelTree;
     }
 
-    return new BroccoliDebug(fbTransform(vendorTree), 'ember-cli-mousewheel:vendor-tree');
+    return new BroccoliDebug(
+      fbTransform(vendorTree), 'ember-cli-mousewheel:vendor-tree'
+    );
   },
 
   included: function(app) {

--- a/index.js
+++ b/index.js
@@ -1,16 +1,40 @@
 /* jshint node: true */
 'use strict';
 var path = require('path');
+var Funnel = require('broccoli-funnel');
+var mergeTrees = require('broccoli-merge-trees');
+var BroccoliDebug = require('broccoli-debug');
+var fbTransform = require('fastboot-transform');
 
 module.exports = {
   name: 'ember-cli-mousewheel',
-  
+
   blueprintsPath: function() {
     return path.join(__dirname, 'blueprints');
   },
 
+  treeForVendor: function(vendorTree) {
+    var mousewheelDir = path.dirname(require.resolve('jquery.mousewheel'));
+
+    var mousewheelTree = new Funnel(mousewheelDir, {
+      files: ['jquery.mousewheel.js']
+    });
+    mousewheelTree = new BroccoliDebug(mousewheelTree, 'ember-cli-mousewheel:mousewheel-tree');
+
+    if (vendorTree) {
+      vendorTree = mergeTrees([vendorTree, mousewheelTree]);
+    } else {
+      vendorTree = mousewheelTree;
+    }
+
+    return new BroccoliDebug(fbTransform(vendorTree), 'ember-cli-mousewheel:vendor-tree');
+  },
+
   included: function(app) {
     this._super.included(app);
-    this.app.import(app.bowerDirectory + '/jquery-mousewheel/jquery.mousewheel.js');
+
+    app.import({
+      development: 'vendor/jquery.mousewheel.js'
+    });
   }
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
+    "broccoli-debug": "^0.6.3",
+    "broccoli-funnel": "^2.0.1",
+    "broccoli-merge-trees": "^2.0.0",
     "ember-cli": "1.13.13",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
@@ -48,7 +51,9 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.5",
+    "fastboot-transform": "^0.1.2",
+    "jquery.mousewheel": "^3.1.9"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Hi there, ember-cli-fastboot >= 1.0 creates only one build for both browser and FastBoot. Which means your assets that only run in browser need guard around it.

Here is the changes can get your addon be compatible with latest ember-cli build.

Corresponds to systembugtj/ember-cli-panzoom#3